### PR TITLE
bump gruntwork installer version to 0.36

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   gruntwork-installer-version:
     description: 'gruntwork-installer version'
     required: true
-    default: 'v0.0.34'
+    default: 'v0.0.36'
   terraform-aws-ci-version:
     description: 'terraform-aws-ci version'
     required: true


### PR DESCRIPTION
I've just bumped the version of the gruntwork installer to 0.36 - in the hopes it will update kubergrunt
TODO: maybe we should install a specific version of kubergrunt?