### PR TITLE
SREBP-593 - Add option to use the Docker Image Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.2] - 2021-04-13
+## [0.1.2] - 2021-04-23
 
 ### Changed
 
 - Added support for `docker-image-builder` via the `docker-image-build` command.
-  - The new command expects the exact same inputs as the previously available Terragrunt commands.
+  - The new command expects an additional optional `build_args` input that provides a string of build arguments
+    that will be passed into the Docker container that is being built. 
+    - Multiple arguments must be supplied to the action as multiple instances of the `--build-arg` flag like this - 
+      `build_args: --build-arg ARG1 --build-arg ARG2`.
 
 ## [0.1.1] - 2021-03-04 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2021-04-13
+
+### Changed
+
+- Added support for `docker-image-builder` via the `docker-image-build` command.
+  - The new command expects the exact same inputs as the previously available Terragrunt commands.
+
 ## [0.1.1] - 2021-03-04 
 
 ### Changed
@@ -18,5 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Composite run GitHub Action for invoking the ECS deploy runner.
 - Helper scripts that install the dependencies of the action.
 
+[0.1.2]: https://github.com/distil/ecs-deploy-runner-github-action/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/distil/ecs-deploy-runner-github-action/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/distil/ecs-deploy-runner-github-action/releases/tag/v0.1.0

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
     - id: set-friendly-ref
       run: |
         if [[ ! -z "$GITHUB_HEAD_REF" ]]; then
-          echo 'FRIENDLY_REF=${{ github.event.pull_request.head.sha }}' >> $GITHUB_ENV
+          echo 'FRIENDLY_REF=${{ github.event.pull_request.head.ref }}' >> $GITHUB_ENV
         else
           echo 'FRIENDLY_REF=$GITHUB_REF' >> $GITHUB_ENV
         fi

--- a/action.yml
+++ b/action.yml
@@ -39,5 +39,5 @@ runs:
       run: ${{ github.action_path }}/helpers/install.sh ${{ inputs.gruntwork-installer-version }} ${{ inputs.terraform-aws-ci-version }} ${{ inputs.terraform-aws-security-version }}
       shell: bash
     - id: run-command
-      run: ${{ github.action_path }}/helpers/deploy.sh ${{ env.AWS_ACCOUNT_ID }} ${{ env.AWS_REGION }} ${{ github.repository }}.git ${{ env.FRIENDLY_REF }} ${{ inputs.command }} "${{ inputs.build_args }}"
+      run: ${{ github.action_path }}/helpers/deploy.sh ${{ env.AWS_ACCOUNT_ID }} ${{ env.AWS_REGION }} ${{ github.repository }}.git ${{ env.FRIENDLY_REF }} ${{ inputs.command }} '${{ inputs.build_args }}'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -35,9 +35,12 @@ runs:
           echo 'FRIENDLY_REF=$GITHUB_REF' >> $GITHUB_ENV
         fi
       shell: bash
+    - id: set-build-args
+      run: echo 'BUILD_ARGS=${{ inputs.build_args }}' >> $GITHUB_ENV
+      shell: bash
     - id: install-helpers
       run: ${{ github.action_path }}/helpers/install.sh ${{ inputs.gruntwork-installer-version }} ${{ inputs.terraform-aws-ci-version }} ${{ inputs.terraform-aws-security-version }}
       shell: bash
     - id: run-command
-      run: ${{ github.action_path }}/helpers/deploy.sh ${{ env.AWS_ACCOUNT_ID }} ${{ env.AWS_REGION }} ${{ github.repository }}.git ${{ env.FRIENDLY_REF }} ${{ inputs.command }} '${{ inputs.build_args }}'
+      run: ${{ github.action_path }}/helpers/deploy.sh ${{ env.AWS_ACCOUNT_ID }} ${{ env.AWS_REGION }} ${{ github.repository }}.git ${{ env.FRIENDLY_REF }} ${{ inputs.command }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -30,9 +30,17 @@ runs:
     - id: set-friendly-ref
       run: |
         if [[ ! -z "$GITHUB_HEAD_REF" ]]; then
-          echo 'FRIENDLY_REF=${{ github.event.pull_request.head.ref }}' >> $GITHUB_ENV
+          echo 'FRIENDLY_REF=$GITHUB_HEAD_REF' >> $GITHUB_ENV
         else
           echo 'FRIENDLY_REF=$GITHUB_REF' >> $GITHUB_ENV
+        fi
+      shell: bash
+    - id: set-version
+      run: |
+        if [[ ! -z "$GITHUB_HEAD_REF" ]]; then
+          echo 'VERSION=$GITHUB_HEAD_REF' >> $GITHUB_ENV
+        else
+          echo 'VERSION=${GITHUB_REF/refs\/tags\//}' >> $GITHUB_ENV
         fi
       shell: bash
     - id: set-build-args
@@ -42,5 +50,5 @@ runs:
       run: ${{ github.action_path }}/helpers/install.sh ${{ inputs.gruntwork-installer-version }} ${{ inputs.terraform-aws-ci-version }} ${{ inputs.terraform-aws-security-version }}
       shell: bash
     - id: run-command
-      run: ${{ github.action_path }}/helpers/deploy.sh ${{ env.AWS_ACCOUNT_ID }} ${{ env.AWS_REGION }} ${{ github.repository }}.git ${{ env.FRIENDLY_REF }} ${{ inputs.command }}
+      run: ${{ github.action_path }}/helpers/deploy.sh ${{ env.AWS_ACCOUNT_ID }} ${{ env.AWS_REGION }} ${{ github.repository }}.git ${{ env.FRIENDLY_REF }} ${{ env.VERSION }} ${{ inputs.command }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: true
     default: 'main'
   command:
-    description: 'Command to run (plan/apply)'
+    description: 'Command to run (plan/apply/docker-image-build)'
     required: true
 runs:
   using: "composite"
@@ -35,5 +35,5 @@ runs:
       run: ${{ github.action_path }}/helpers/install.sh ${{ inputs.gruntwork-installer-version }} ${{ inputs.terraform-aws-ci-version }} ${{ inputs.terraform-aws-security-version }}
       shell: bash
     - id: run-command
-      run: ${{ github.action_path }}/helpers/deploy.sh ${{ env.AWS_ACCOUNT_ID }} ${{ env.AWS_REGION }} git@github.com:${{ github.repository }}.git ${{ env.FRIENDLY_REF }} ${{ inputs.command }}
+      run: ${{ github.action_path }}/helpers/deploy.sh ${{ env.AWS_ACCOUNT_ID }} ${{ env.AWS_REGION }} ${{ github.repository }}.git ${{ env.FRIENDLY_REF }} ${{ inputs.command }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -39,5 +39,5 @@ runs:
       run: ${{ github.action_path }}/helpers/install.sh ${{ inputs.gruntwork-installer-version }} ${{ inputs.terraform-aws-ci-version }} ${{ inputs.terraform-aws-security-version }}
       shell: bash
     - id: run-command
-      run: ${{ github.action_path }}/helpers/deploy.sh ${{ env.AWS_ACCOUNT_ID }} ${{ env.AWS_REGION }} ${{ github.repository }}.git ${{ env.FRIENDLY_REF }} ${{ inputs.command }} ${{ inputs.build_args }}
+      run: ${{ github.action_path }}/helpers/deploy.sh ${{ env.AWS_ACCOUNT_ID }} ${{ env.AWS_REGION }} ${{ github.repository }}.git ${{ env.FRIENDLY_REF }} ${{ inputs.command }} "${{ inputs.build_args }}"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
   command:
     description: 'Command to run (plan/apply/docker-image-build)'
     required: true
+  build_args:
+    description: 'Build time arguments to use when building Docker images'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -35,5 +39,5 @@ runs:
       run: ${{ github.action_path }}/helpers/install.sh ${{ inputs.gruntwork-installer-version }} ${{ inputs.terraform-aws-ci-version }} ${{ inputs.terraform-aws-security-version }}
       shell: bash
     - id: run-command
-      run: ${{ github.action_path }}/helpers/deploy.sh ${{ env.AWS_ACCOUNT_ID }} ${{ env.AWS_REGION }} ${{ github.repository }}.git ${{ env.FRIENDLY_REF }} ${{ inputs.command }}
+      run: ${{ github.action_path }}/helpers/deploy.sh ${{ env.AWS_ACCOUNT_ID }} ${{ env.AWS_REGION }} ${{ github.repository }}.git ${{ env.FRIENDLY_REF }} ${{ inputs.command }} ${{ inputs.build_args }}
       shell: bash

--- a/helpers/deploy.sh
+++ b/helpers/deploy.sh
@@ -10,7 +10,7 @@
 # - COMMAND : The command to run. Should be one of plan or apply.
 #
 
-set -euxo pipefail
+set -euo pipefail
 
 # Function that invoke the ECS Deploy Runner using the infrastructure-deployer CLI. This will also make sure to assume
 # the correct IAM role.

--- a/helpers/deploy.sh
+++ b/helpers/deploy.sh
@@ -20,7 +20,6 @@ function invoke_infrastructure_deployer {
   local -r repo="$3"
   local -r ref="$4"
   local -r command="$5"
-  local -r build_args="$6"
 
   local assume_role_exports
   assume_role_exports="$(aws-auth --role-arn "arn:aws:iam::$aws_account_id:role/allow-ecs-deploy-runner-invoker-access" --role-duration-seconds 3600)"
@@ -39,7 +38,7 @@ function invoke_infrastructure_deployer {
     infrastructure-deployer --aws-region "$region" -- "$container" infrastructure-deploy-script --repo git@github.com:"$repo" --ref "$ref" --binary "terragrunt" --command "$command" --deploy-path "$GITHUB_WORKFLOW")
   elif [[ "$container" == "docker-image-builder" ]]; then
   (eval "$assume_role_exports" && \
-    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$ref" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$ref" "$build_args")
+    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$ref" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$ref" "$BUILD_ARGS")
   fi
 
 }

--- a/helpers/deploy.sh
+++ b/helpers/deploy.sh
@@ -19,7 +19,8 @@ function invoke_infrastructure_deployer {
   local -r region="$2"
   local -r repo="$3"
   local -r ref="$4"
-  local -r command="$5"
+  local -r version="$5"
+  local -r command="$6"
 
   local assume_role_exports
   assume_role_exports="$(aws-auth --role-arn "arn:aws:iam::$aws_account_id:role/allow-ecs-deploy-runner-invoker-access" --role-duration-seconds 3600)"
@@ -38,7 +39,7 @@ function invoke_infrastructure_deployer {
     infrastructure-deployer --aws-region "$region" -- "$container" infrastructure-deploy-script --repo git@github.com:"$repo" --ref "$ref" --binary "terragrunt" --command "$command" --deploy-path "$GITHUB_WORKFLOW")
   elif [[ "$container" == "docker-image-builder" ]]; then
   (eval "$assume_role_exports" && \
-    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$ref" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$ref" $BUILD_ARGS)
+    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$ref" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$version" $BUILD_ARGS)
   fi
 
 }

--- a/helpers/deploy.sh
+++ b/helpers/deploy.sh
@@ -38,7 +38,7 @@ function invoke_infrastructure_deployer {
     infrastructure-deployer --aws-region "$region" -- "$container" infrastructure-deploy-script --repo git@github.com:"$repo" --ref "$ref" --binary "terragrunt" --command "$command" --deploy-path "$GITHUB_WORKFLOW")
   elif [[ "$container" == "docker-image-builder" ]]; then
   (eval "$assume_role_exports" && \
-    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$ref" --command "$command" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$ref")
+    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$ref" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$ref")
   fi
 
 }

--- a/helpers/deploy.sh
+++ b/helpers/deploy.sh
@@ -38,7 +38,7 @@ function invoke_infrastructure_deployer {
     infrastructure-deployer --aws-region "$region" -- "$container" infrastructure-deploy-script --repo git@github.com:"$repo" --ref "$ref" --binary "terragrunt" --command "$command" --deploy-path "$GITHUB_WORKFLOW")
   elif [[ "$container" == "docker-image-builder" ]]; then
   (eval "$assume_role_exports" && \
-    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$BRANCH_NAME" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$ref")
+    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$ref" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$ref")
   fi
 
 }

--- a/helpers/deploy.sh
+++ b/helpers/deploy.sh
@@ -38,7 +38,7 @@ function invoke_infrastructure_deployer {
     infrastructure-deployer --aws-region "$region" -- "$container" infrastructure-deploy-script --repo git@github.com:"$repo" --ref "$ref" --binary "terragrunt" --command "$command" --deploy-path "$GITHUB_WORKFLOW")
   elif [[ "$container" == "docker-image-builder" ]]; then
   (eval "$assume_role_exports" && \
-    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$ref" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$ref")
+    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$BRANCH_NAME" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$ref")
   fi
 
 }

--- a/helpers/deploy.sh
+++ b/helpers/deploy.sh
@@ -38,7 +38,7 @@ function invoke_infrastructure_deployer {
     infrastructure-deployer --aws-region "$region" -- "$container" infrastructure-deploy-script --repo git@github.com:"$repo" --ref "$ref" --binary "terragrunt" --command "$command" --deploy-path "$GITHUB_WORKFLOW")
   elif [[ "$container" == "docker-image-builder" ]]; then
   (eval "$assume_role_exports" && \
-    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$ref" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$ref" "$BUILD_ARGS")
+    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$ref" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$ref")
   fi
 
 }

--- a/helpers/deploy.sh
+++ b/helpers/deploy.sh
@@ -10,7 +10,7 @@
 # - COMMAND : The command to run. Should be one of plan or apply.
 #
 
-set -euo pipefail
+set -euxo pipefail
 
 # Function that invoke the ECS Deploy Runner using the infrastructure-deployer CLI. This will also make sure to assume
 # the correct IAM role.

--- a/helpers/deploy.sh
+++ b/helpers/deploy.sh
@@ -20,6 +20,7 @@ function invoke_infrastructure_deployer {
   local -r repo="$3"
   local -r ref="$4"
   local -r command="$5"
+  local -r build_args="$6"
 
   local assume_role_exports
   assume_role_exports="$(aws-auth --role-arn "arn:aws:iam::$aws_account_id:role/allow-ecs-deploy-runner-invoker-access" --role-duration-seconds 3600)"
@@ -38,7 +39,7 @@ function invoke_infrastructure_deployer {
     infrastructure-deployer --aws-region "$region" -- "$container" infrastructure-deploy-script --repo git@github.com:"$repo" --ref "$ref" --binary "terragrunt" --command "$command" --deploy-path "$GITHUB_WORKFLOW")
   elif [[ "$container" == "docker-image-builder" ]]; then
   (eval "$assume_role_exports" && \
-    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$ref" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$ref")
+    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$ref" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$ref" "$build_args")
   fi
 
 }

--- a/helpers/deploy.sh
+++ b/helpers/deploy.sh
@@ -38,7 +38,7 @@ function invoke_infrastructure_deployer {
     infrastructure-deployer --aws-region "$region" -- "$container" infrastructure-deploy-script --repo git@github.com:"$repo" --ref "$ref" --binary "terragrunt" --command "$command" --deploy-path "$GITHUB_WORKFLOW")
   elif [[ "$container" == "docker-image-builder" ]]; then
   (eval "$assume_role_exports" && \
-    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$ref" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$ref")
+    infrastructure-deployer --aws-region "$region" -- "$container" build-docker-image --repo https://github.com/"$repo" --ref "$ref" --context-path "$GITHUB_WORKFLOW" --docker-image-tag "$aws_account_id.dkr.ecr.$region.amazonaws.com/$GITHUB_WORKFLOW:$ref" $BUILD_ARGS)
   fi
 
 }


### PR DESCRIPTION
This PR adds an extra function that enables the use of the `docker-image-builder` feature of the ECS Deploy Runner. It will allow users to use the deploy runner to build and deploy Docker images from code stored in GitHub directly to AWS ECR.